### PR TITLE
add apt-get update for the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN chown -R root /app
 # Fix for cryptography library installation via pip
 ENV LD_LIBRARY_PATH $HOME/anaconda/lib
 
+#get apt packages 
+RUN apt-get update
+
 # Install missing dependencies prior to installing requirements.txt
 RUN apt-get install -y libffi-dev libxml2-dev libxslt1-dev
 


### PR DESCRIPTION
This will resolve the below issue

```
 ---> Using cache
 ---> 41e825e2b50d
Step 5 : RUN apt-get install -y libffi-dev libxml2-dev libxslt1-dev
 ---> Running in 56e21c9b0daf
Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  libxml2 libxslt1.1 sgml-base xml-core
Suggested packages:
  sgml-base-doc debhelper
The following NEW packages will be installed:
  libffi-dev libxml2 libxml2-dev libxslt1-dev libxslt1.1 sgml-base xml-core
0 upgraded, 7 newly installed, 0 to remove and 0 not upgraded.
Need to get 2336 kB of archives.
After this operation, 8196 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu/ precise-updates/main libxslt1.1 amd64 1.1.26-8ubuntu1.3 [167 kB]
Get:2 http://archive.ubuntu.com/ubuntu/ precise/main sgml-base all 1.26+nmu1ubuntu1 [8360 B]
Get:3 http://archive.ubuntu.com/ubuntu/ precise/main xml-core all 0.13 [23.4 kB]
Get:4 http://archive.ubuntu.com/ubuntu/ precise-updates/main libxslt1-dev amd64 1.1.26-8ubuntu1.3 [564 kB]
Get:5 http://archive.ubuntu.com/ubuntu/ precise/main libffi-dev amd64 3.0.11~rc1-5 [96.1 kB]
Err http://archive.ubuntu.com/ubuntu/ precise-security/main libxml2 amd64 2.7.8.dfsg-5.1ubuntu4.9
  404  Not Found [IP: 91.189.88.153 80]
Err http://archive.ubuntu.com/ubuntu/ precise-security/main libxml2-dev amd64 2.7.8.dfsg-5.1ubuntu4.9
  404  Not Found [IP: 91.189.88.153 80]
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.7.8.dfsg-5.1ubuntu4.9_amd64.deb  404  Not Found [IP: 91.189.88.153 80]
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-dev_2.7.8.dfsg-5.1ubuntu4.9_amd64.deb  404  Not Found [IP: 91.189.88.153 80]
Fetched 859 kB in 1s (633 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
